### PR TITLE
Header application/x-www-form-urlencoded in curl example

### DIFF
--- a/PHP/basic/using_curl.php
+++ b/PHP/basic/using_curl.php
@@ -29,6 +29,7 @@ function api_call($action, array $params, $show_header = false)
     $curl = curl_init();
     curl_setopt($curl, CURLOPT_URL, getUrl($action));
     curl_setopt($curl, CURLOPT_POST, true);
+    curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-Type: application/x-www-form-urlencoded'));
     curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($params));
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);


### PR DESCRIPTION
We would like to inform you that from the date of November 1, 2022 API will support only requests type application/x-www-form-urlencoded'. All queries that do not meet this requirement will be rejected. Please take the above changes into account in your application.